### PR TITLE
Correctly document usage of the "attachments" parameter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprot
 const server = new Server(
   {
     name: "task-manager-server",
-    version: "1.3.0"
+    version: "1.3.1"
   },
   {
     capabilities: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "taskqueue-mcp",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "taskqueue-mcp",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"@ai-sdk/deepseek": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "taskqueue-mcp",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Task Queue MCP Server",
 	"author": "Christopher C. Smith (christopher.smith@promptlytechnologies.com)",
 	"main": "dist/index.js",

--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -16,7 +16,7 @@ const program = new Command();
 program
   .name("taskqueue")
   .description("CLI for the Task Manager MCP Server")
-  .version("1.3.0")
+  .version("1.3.1")
   .option(
     '-f, --file-path <path>',
     'Specify the path to the tasks JSON file. Overrides TASK_MANAGER_FILE_PATH env var.'

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -216,7 +216,7 @@ const generateProjectPlanTool: Tool = {
         items: {
           type: "string",
         },
-        description: "Optional array of file contents or text to provide as context.",
+        description: "Optional array of paths to files to attach as context. There is no need to read the files before calling this tool!",
       },
     },
     required: ["prompt", "provider", "model"],


### PR DESCRIPTION
The MCP Server now exposes correct instructions on how to use the "attachments" parameter when calling the "generate_project_plan" tool